### PR TITLE
Fix matrix type detection

### DIFF
--- a/R/MAIN.R
+++ b/R/MAIN.R
@@ -85,7 +85,7 @@ genius_addY <- function(Y,A,G,formula=A~G,alpha=0.05,lower=-10,upper=10) {
 	if (is.data.frame(G)) {
 		G=data.matrix(G)
 	}
-	if (class(G) == "matrix") {
+	if (inherits(G, "matrix")) {
 		#number of IVs
   		nIV =dim(G)[2];
 		#sample size


### PR DESCRIPTION
When passing a matrix into the argument `G`, the current version throws error 
```
"Error in if (class(G) == "matrix") { : the condition has length > 1"
```
as a matrix defined with, for example, `class(matrix(1:10, nrow = 2))` returns `c("matrix", "array")` instead of only `"matrix"`.

This version checks whether G inherits the class "matrix" instead - checks for coercibility.
The change has been made on line 88.